### PR TITLE
Fix token scope test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM swift:3.1
+FROM swift:5.7
 
 WORKDIR /package
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
     <br>
     <br>
     <a href="https://swift.org">
-        <img src="http://img.shields.io/badge/Swift-4-brightgreen.svg" alt="Language">
+        <img src="http://img.shields.io/badge/Swift-5.7-brightgreen.svg" alt="Language">
     </a>
-    <a href="https://travis-ci.org/brokenhandsio/vapor-oauth">
-        <img src="https://travis-ci.org/brokenhandsio/vapor-oauth.svg?branch=master" alt="Build Status">
+    <a href="https://github.com/brokenhandsio/vapor-oauth/actions/workflows/main.yml">
+        <img src="https://github.com/brokenhandsio/vapor-oauth/actions/workflows/main.yml/badge.svg" alt="Test Status">
     </a>
     <a href="https://codecov.io/gh/brokenhandsio/vapor-oauth">
         <img src="https://codecov.io/gh/brokenhandsio/vapor-oauth/branch/master/graph/badge.svg" alt="Code Coverage">

--- a/Sources/VaporOAuth/RouteHandlers/TokenHandlers/RefreshTokenHandler.swift
+++ b/Sources/VaporOAuth/RouteHandlers/TokenHandlers/RefreshTokenHandler.swift
@@ -42,6 +42,9 @@ struct RefreshTokenHandler {
                                                                          description: "Request contained elevated scopes")
                     }
                 }
+            } else {
+                return try tokenResponseGenerator.createResponse(error: OAuthResponseParameters.ErrorType.invalidScope,
+                                                                 description: "Request contained elevated scopes")
             }
 
             try await tokenManager.updateRefreshToken(refreshTokenRequest.refreshToken, scopes: scopes)

--- a/Sources/VaporOAuth/RouteHandlers/TokenHandlers/RefreshTokenHandler.swift
+++ b/Sources/VaporOAuth/RouteHandlers/TokenHandlers/RefreshTokenHandler.swift
@@ -43,8 +43,10 @@ struct RefreshTokenHandler {
                     }
                 }
             } else {
-                return try tokenResponseGenerator.createResponse(error: OAuthResponseParameters.ErrorType.invalidScope,
-                                                                 description: "Request contained elevated scopes")
+                return try tokenResponseGenerator.createResponse(
+                    error: OAuthResponseParameters.ErrorType.invalidScope,
+                    description: "Request contained elevated scopes"
+                )
             }
 
             try await tokenManager.updateRefreshToken(refreshTokenRequest.refreshToken, scopes: scopes)

--- a/Tests/VaporOAuthTests/AuthorizationTests/AuthorizationResponseTests.swift
+++ b/Tests/VaporOAuthTests/AuthorizationTests/AuthorizationResponseTests.swift
@@ -137,6 +137,8 @@ class AuthorizationResponseTests: XCTestCase {
             registeredUsers: [TestDataBuilder.anyOAuthUser()]
         )
 
+        try await Task.sleep(nanoseconds: 1) // Without this the tests are crashing (segmentation fault) on ubuntu
+
         let clientID = "ABCDE1234"
         let redirectURI = "http://api.brokenhands.io/callback"
         let newClient = OAuthClient(clientID: clientID, redirectURIs: [redirectURI], allowedGrantType: .authorization)

--- a/Tests/VaporOAuthTests/AuthorizationTests/AuthorizationResponseTests.swift
+++ b/Tests/VaporOAuthTests/AuthorizationTests/AuthorizationResponseTests.swift
@@ -47,6 +47,11 @@ class AuthorizationResponseTests: XCTestCase {
         )
     }
 
+    override func tearDown() async throws {
+        app.shutdown()
+        try await super.tearDown()
+    }
+
     // MARK: - Tests
 
     func testThatCorrectErrorCodeReturnedIfUserDoesNotAuthorizeApplication() async throws {

--- a/Tests/VaporOAuthTests/GrantTests/ImplicitGrantTests.swift
+++ b/Tests/VaporOAuthTests/GrantTests/ImplicitGrantTests.swift
@@ -250,6 +250,8 @@ class ImplicitGrantTests: XCTestCase {
             registeredUsers: [TestDataBuilder.anyOAuthUser()]
         )
 
+        try await Task.sleep(nanoseconds: 1) // Without this the tests are crashing (segmentation fault) on ubuntu
+
         let clientID = "ABCDE1234"
         let redirectURI = "http://api.brokenhands.io/callback"
         let newClient = OAuthClient(clientID: clientID, redirectURIs: [redirectURI], allowedGrantType: .implicit)
@@ -360,6 +362,8 @@ class ImplicitGrantTests: XCTestCase {
             registeredUsers: [user]
         )
 
+        try await Task.sleep(nanoseconds: 1) // Without this the tests are crashing (segmentation fault) on ubuntu
+
         _ = try await getImplicitGrantResponse(user: user)
 
         guard let token = fakeTokenManager.getAccessToken(accessToken) else {
@@ -392,6 +396,8 @@ class ImplicitGrantTests: XCTestCase {
             validScopes: [scope1, scope2, scope3],
             sessions: fakeSessions
         )
+
+        try await Task.sleep(nanoseconds: 1) // Without this the tests are crashing (segmentation fault) on ubuntu
 
         let response = try await getImplicitGrantResponse(user: nil)
 

--- a/Tests/VaporOAuthTests/GrantTests/PasswordGrantTokenTests.swift
+++ b/Tests/VaporOAuthTests/GrantTests/PasswordGrantTokenTests.swift
@@ -57,6 +57,11 @@ class PasswordGrantTokenTests: XCTestCase {
         fakeTokenManager.refreshTokenToReturn = refreshToken
     }
 
+    override func tearDown() async throws {
+        app.shutdown()
+        try await super.tearDown()
+    }
+
     // MARK: - Tests
 
     func testCorrectErrorWhenGrantTypeNotSupplied() async throws {

--- a/Tests/VaporOAuthTests/GrantTests/TokenRefreshTests.swift
+++ b/Tests/VaporOAuthTests/GrantTests/TokenRefreshTests.swift
@@ -47,6 +47,11 @@ class TokenRefreshTests: XCTestCase {
         fakeTokenManager.refreshTokens[refreshTokenString] = validRefreshToken
     }
 
+    override func tearDown() async throws {
+        app.shutdown()
+        try await super.tearDown()
+    }
+
     // MARK: - Tests
     func testCorrectErrorWhenGrantTypeNotSupplied() async throws {
         let response = try await getTokenResponse(grantType: nil)

--- a/Tests/VaporOAuthTests/IntegrationTests/AuthCodeResourceServerTests.swift
+++ b/Tests/VaporOAuthTests/IntegrationTests/AuthCodeResourceServerTests.swift
@@ -73,6 +73,11 @@ class AuthCodeResourceServerTests: XCTestCase {
         }
     }
 
+    override func tearDown() async throws {
+        app.shutdown()
+        try await super.tearDown()
+    }
+
     // MARK: - Tests
     // func testThatClientCanAccessResourceServerWithValidAuthCodeToken() async throws {
     //     // Get Auth Code

--- a/Tests/VaporOAuthTests/TokenIntrospectionTests/TokenIntrospectionTests.swift
+++ b/Tests/VaporOAuthTests/TokenIntrospectionTests/TokenIntrospectionTests.swift
@@ -42,6 +42,11 @@ class TokenIntrospectionTests: XCTestCase {
         fakeTokenManager.accessTokens[accessToken] = validToken
     }
 
+    override func tearDown() async throws {
+        app.shutdown()
+        try await super.tearDown()
+    }
+
     // MARK: - Tests
     func testCorrectErrorWhenTokenParameterNotSuppliedInRequest() async throws {
         let response = try await getInfoResponse(token: nil)


### PR DESCRIPTION
Looks like I accidentally removed an else block during the Vapor 4 migration.