### PR TITLE
Make functions of `ResourceServerRetriever` async

### DIFF
--- a/Sources/VaporOAuth/DefaultImplementations/EmptyResourceServerRetriever.swift
+++ b/Sources/VaporOAuth/DefaultImplementations/EmptyResourceServerRetriever.swift
@@ -2,7 +2,7 @@ public struct EmptyResourceServerRetriever: ResourceServerRetriever {
 
     public init() {}
 
-    public func getServer(_ username: String) -> OAuthResourceServer? {
+    public func getServer(_ username: String) async throws -> OAuthResourceServer? {
         return nil
     }
 }

--- a/Sources/VaporOAuth/Middleware/TokenIntrospectionAuthenticationMiddleware.swift
+++ b/Sources/VaporOAuth/Middleware/TokenIntrospectionAuthenticationMiddleware.swift
@@ -8,7 +8,7 @@ struct TokenIntrospectionAuthMiddleware: AsyncMiddleware {
             throw Abort(.unauthorized)
         }
 
-        try resourceServerAuthenticator.authenticate(credentials: basicAuthorization)
+        try await resourceServerAuthenticator.authenticate(credentials: basicAuthorization)
 
         return try await next.respond(to: request)
     }

--- a/Sources/VaporOAuth/Protocols/ResourceServerRetriever.swift
+++ b/Sources/VaporOAuth/Protocols/ResourceServerRetriever.swift
@@ -1,3 +1,3 @@
 public protocol ResourceServerRetriever {
-    func getServer(_ username: String) -> OAuthResourceServer?
+    func getServer(_ username: String) async throws -> OAuthResourceServer?
 }

--- a/Sources/VaporOAuth/Validators/ResourceServerAuthenticator.swift
+++ b/Sources/VaporOAuth/Validators/ResourceServerAuthenticator.swift
@@ -4,8 +4,8 @@ struct ResourceServerAuthenticator {
 
     let resourceServerRetriever: ResourceServerRetriever
 
-    func authenticate(credentials: BasicAuthorization) throws {
-        guard let resourceServer = resourceServerRetriever.getServer(credentials.username) else {
+    func authenticate(credentials: BasicAuthorization) async throws {
+        guard let resourceServer = try await resourceServerRetriever.getServer(credentials.username) else {
             throw Abort(.unauthorized)
         }
 

--- a/Tests/VaporOAuthTests/DefaultImplementationTests/DefaultImplementationTests.swift
+++ b/Tests/VaporOAuthTests/DefaultImplementationTests/DefaultImplementationTests.swift
@@ -3,10 +3,11 @@ import XCTVapor
 
 class DefaultImplementationTests: XCTestCase {
     // MARK: - Tests
-    func testThatEmptyResourceServerRetrieverReturnsNilWhenGettingResourceServer() {
+    func testThatEmptyResourceServerRetrieverReturnsNilWhenGettingResourceServer() async throws {
         let emptyResourceServerRetriever = EmptyResourceServerRetriever()
 
-        XCTAssertNil(emptyResourceServerRetriever.getServer("some username"))
+        let server = try await emptyResourceServerRetriever.getServer("some username")
+        XCTAssertNil(server)
     }
 
     func testThatEmptyUserManagerReturnsNilWhenAttemptingToAuthenticate() async throws {

--- a/Tests/VaporOAuthTests/Fakes/FakeResourceServerRetriever.swift
+++ b/Tests/VaporOAuthTests/Fakes/FakeResourceServerRetriever.swift
@@ -4,7 +4,7 @@ class FakeResourceServerRetriever: ResourceServerRetriever {
     
     var resourceServers: [String: OAuthResourceServer] = [:]
     
-    func getServer(_ username: String) -> OAuthResourceServer? {
+    func getServer(_ username: String) async throws -> OAuthResourceServer? {
         return resourceServers[username]
     }
 }


### PR DESCRIPTION
This pull request makes the last public protocol requirement of this library uses Swift Concurrency.