### PR TITLE
Handling Expired Device Codes in OAuth Token Process

### DIFF
--- a/Sources/VaporOAuth/DefaultImplementations/EmptyCodeManager.swift
+++ b/Sources/VaporOAuth/DefaultImplementations/EmptyCodeManager.swift
@@ -15,4 +15,14 @@ public struct EmptyCodeManager: CodeManager {
     }
 
     public func codeUsed(_ code: OAuthCode) {}
+
+    public func getDeviceCode(_ deviceCode: String) -> OAuthDeviceCode? {
+        return nil
+    }
+
+    public func generateDeviceCode(userID: String, clientID: String, scopes: [String]?) throws -> String {
+        return ""
+    }
+
+    public func deviceCodeUsed(_ deviceCode: OAuthDeviceCode) {}
 }

--- a/Sources/VaporOAuth/Models/OAuthDeviceCode.swift
+++ b/Sources/VaporOAuth/Models/OAuthDeviceCode.swift
@@ -1,10 +1,3 @@
-//
-//  OAuthDeviceCode.swift
-//
-//
-//  Created by Vamsi Madduluri on 24/08/23.
-//
-
 import Foundation
 
 public final class OAuthDeviceCode {

--- a/Sources/VaporOAuth/Models/OAuthDeviceCode.swift
+++ b/Sources/VaporOAuth/Models/OAuthDeviceCode.swift
@@ -1,0 +1,39 @@
+//
+//  OAuthDeviceCode.swift
+//
+//
+//  Created by Vamsi Madduluri on 24/08/23.
+//
+
+import Foundation
+
+public final class OAuthDeviceCode {
+    public let deviceCodeID: String
+    public let userCode: String
+    public let clientID: String
+    public let userID: String?
+    public let expiryDate: Date
+    public let scopes: [String]?
+
+    public var extend: [String: Any] = [:]
+
+    public init(
+        deviceCodeID: String,
+        userCode: String,
+        clientID: String,
+        userID: String?,
+        expiryDate: Date,
+        scopes: [String]?
+    ) {
+        self.deviceCodeID = deviceCodeID
+        self.userCode = userCode
+        self.clientID = clientID
+        self.userID = userID
+        self.expiryDate = expiryDate
+        self.scopes = scopes
+    }
+
+    public var isExpired: Bool {
+        return Date() > expiryDate
+    }
+}

--- a/Sources/VaporOAuth/Protocols/CodeManager.swift
+++ b/Sources/VaporOAuth/Protocols/CodeManager.swift
@@ -6,4 +6,7 @@ public protocol CodeManager {
     // This is explicit to ensure that the code is marked as used or deleted (it could be implied that this is done when you call
     // `getCode` but it is called explicitly to remind developers to ensure that codes can't be reused)
     func codeUsed(_ code: OAuthCode) async throws
+    func generateDeviceCode(userID: String, clientID: String, scopes: [String]?) async throws -> String
+    func getDeviceCode(_ deviceCode: String) async throws -> OAuthDeviceCode?
+    func deviceCodeUsed(_ deviceCode: OAuthDeviceCode) async throws
 }

--- a/Sources/VaporOAuth/Protocols/TokenManager.swift
+++ b/Sources/VaporOAuth/Protocols/TokenManager.swift
@@ -18,4 +18,6 @@ public protocol TokenManager {
     func getRefreshToken(_ refreshToken: String) async throws -> RefreshToken?
     func getAccessToken(_ accessToken: String) async throws -> AccessToken?
     func updateRefreshToken(_ refreshToken: RefreshToken, scopes: [String]) async throws
+    func getDeviceCode(_ deviceCodeString: String) async throws -> OAuthDeviceCode?
+    func deviceCodeUsed(_ deviceCode: OAuthDeviceCode) async throws
 }

--- a/Sources/VaporOAuth/Protocols/TokenManager.swift
+++ b/Sources/VaporOAuth/Protocols/TokenManager.swift
@@ -18,6 +18,4 @@ public protocol TokenManager {
     func getRefreshToken(_ refreshToken: String) async throws -> RefreshToken?
     func getAccessToken(_ accessToken: String) async throws -> AccessToken?
     func updateRefreshToken(_ refreshToken: RefreshToken, scopes: [String]) async throws
-    func getDeviceCode(_ deviceCodeString: String) async throws -> OAuthDeviceCode?
-    func deviceCodeUsed(_ deviceCode: OAuthDeviceCode) async throws
 }

--- a/Sources/VaporOAuth/RouteHandlers/TokenHandler.swift
+++ b/Sources/VaporOAuth/RouteHandlers/TokenHandler.swift
@@ -26,7 +26,8 @@ struct TokenHandler {
         passwordTokenHandler = PasswordTokenHandler(clientValidator: clientValidator, scopeValidator: scopeValidator,
                                                     userManager: userManager, logger: logger, tokenManager: tokenManager,
                                                     tokenResponseGenerator: tokenResponseGenerator)
-        deviceCodeTokenHandler = DeviceCodeTokenHandler(clientValidator: clientValidator, tokenManager: tokenManager,
+        deviceCodeTokenHandler = DeviceCodeTokenHandler(clientValidator: clientValidator, scopeValidator: scopeValidator,
+                                                        tokenManager: tokenManager,
                                                         tokenResponseGenerator: tokenResponseGenerator)
     }
 
@@ -46,7 +47,7 @@ struct TokenHandler {
         case OAuthFlowType.refresh.rawValue:
             return try await refreshTokenHandler.handleRefreshTokenRequest(request)
         case OAuthFlowType.deviceCode.rawValue:
-                return try await deviceCodeTokenHandler.handleDeviceCodeTokenRequest(request)
+            return try await deviceCodeTokenHandler.handleDeviceCodeTokenRequest(request)
         default:
             return try tokenResponseGenerator.createResponse(error: OAuthResponseParameters.ErrorType.unsupportedGrant,
                                                              description: "This server does not support the '\(grantType)' grant type")

--- a/Sources/VaporOAuth/RouteHandlers/TokenHandler.swift
+++ b/Sources/VaporOAuth/RouteHandlers/TokenHandler.swift
@@ -8,6 +8,7 @@ struct TokenHandler {
     let tokenResponseGenerator: TokenResponseGenerator
     let authCodeTokenHandler: AuthCodeTokenHandler
     let passwordTokenHandler: PasswordTokenHandler
+    let deviceCodeTokenHandler: DeviceCodeTokenHandler
 
     init(clientValidator: ClientValidator, tokenManager: TokenManager, scopeValidator: ScopeValidator,
          codeManager: CodeManager, userManager: UserManager, logger: Logger) {
@@ -25,6 +26,8 @@ struct TokenHandler {
         passwordTokenHandler = PasswordTokenHandler(clientValidator: clientValidator, scopeValidator: scopeValidator,
                                                     userManager: userManager, logger: logger, tokenManager: tokenManager,
                                                     tokenResponseGenerator: tokenResponseGenerator)
+        deviceCodeTokenHandler = DeviceCodeTokenHandler(clientValidator: clientValidator, tokenManager: tokenManager,
+                                                        tokenResponseGenerator: tokenResponseGenerator)
     }
 
     func handleRequest(request: Request) async throws -> Response {
@@ -42,6 +45,8 @@ struct TokenHandler {
             return try await clientCredentialsTokenHandler.handleClientCredentialsTokenRequest(request)
         case OAuthFlowType.refresh.rawValue:
             return try await refreshTokenHandler.handleRefreshTokenRequest(request)
+        case OAuthFlowType.deviceCode.rawValue:
+                return try await deviceCodeTokenHandler.handleDeviceCodeTokenRequest(request)
         default:
             return try tokenResponseGenerator.createResponse(error: OAuthResponseParameters.ErrorType.unsupportedGrant,
                                                              description: "This server does not support the '\(grantType)' grant type")

--- a/Sources/VaporOAuth/RouteHandlers/TokenHandler.swift
+++ b/Sources/VaporOAuth/RouteHandlers/TokenHandler.swift
@@ -26,7 +26,7 @@ struct TokenHandler {
         passwordTokenHandler = PasswordTokenHandler(clientValidator: clientValidator, scopeValidator: scopeValidator,
                                                     userManager: userManager, logger: logger, tokenManager: tokenManager,
                                                     tokenResponseGenerator: tokenResponseGenerator)
-        deviceCodeTokenHandler = DeviceCodeTokenHandler(clientValidator: clientValidator, scopeValidator: scopeValidator,
+        deviceCodeTokenHandler = DeviceCodeTokenHandler(clientValidator: clientValidator, scopeValidator: scopeValidator, codeManager: codeManager,
                                                         tokenManager: tokenManager,
                                                         tokenResponseGenerator: tokenResponseGenerator)
     }

--- a/Sources/VaporOAuth/RouteHandlers/TokenHandlers/DeviceCodeTokenHandler.swift
+++ b/Sources/VaporOAuth/RouteHandlers/TokenHandlers/DeviceCodeTokenHandler.swift
@@ -1,0 +1,56 @@
+//
+//  DeviceCodeTokenHandler.swift
+//
+//
+//  Created by Vamsi Madduluri on 24/08/23.
+//
+
+import Vapor
+
+struct DeviceCodeTokenHandler {
+
+    let clientValidator: ClientValidator
+    let tokenManager: TokenManager
+    let tokenResponseGenerator: TokenResponseGenerator
+
+    func handleDeviceCodeTokenRequest(_ request: Request) async throws -> Response {
+        guard let deviceCodeString: String = request.content[OAuthRequestParameters.deviceCode] else {
+            return try tokenResponseGenerator.createResponse(error: OAuthResponseParameters.ErrorType.invalidRequest,
+                                                             description: "Request was missing the 'device_code' parameter")
+        }
+
+        guard let clientID: String = request.content[OAuthRequestParameters.clientID] else {
+            return try tokenResponseGenerator.createResponse(error: OAuthResponseParameters.ErrorType.invalidRequest,
+                                                             description: "Request was missing the 'client_id' parameter")
+        }
+
+        do {
+            try await clientValidator.authenticateClient(clientID: clientID, clientSecret: nil,
+                                                         grantType: .deviceCode)
+        } catch {
+            return try tokenResponseGenerator.createResponse(error: OAuthResponseParameters.ErrorType.invalidClient,
+                                                             description: "Request had invalid client credentials", status: .unauthorized)
+        }
+
+        guard let deviceCode = try await tokenManager.getDeviceCode(deviceCodeString),
+              !deviceCode.isExpired else {
+            let errorDescription = "The device code provided was invalid or expired"
+            return try tokenResponseGenerator.createResponse(error: OAuthResponseParameters.ErrorType.invalidGrant,
+                                                             description: errorDescription)
+        }
+
+        try await tokenManager.deviceCodeUsed(deviceCode)
+
+        let scopes = deviceCode.scopes
+        let expiryTime = 3600
+
+        let (access, refresh) = try await tokenManager.generateAccessRefreshTokens(
+            clientID: clientID, userID: deviceCode.userID,
+            scopes: scopes,
+            accessTokenExpiryTime: expiryTime
+        )
+
+        return try tokenResponseGenerator.createResponse(accessToken: access, refreshToken: refresh, expires: Int(expiryTime),
+                                                         scope: scopes?.joined(separator: " "))
+    }
+}

--- a/Sources/VaporOAuth/RouteHandlers/TokenHandlers/DeviceCodeTokenHandler.swift
+++ b/Sources/VaporOAuth/RouteHandlers/TokenHandlers/DeviceCodeTokenHandler.swift
@@ -1,10 +1,3 @@
-//
-//  DeviceCodeTokenHandler.swift
-//
-//
-//  Created by Vamsi Madduluri on 24/08/23.
-//
-
 import Vapor
 
 struct DeviceCodeTokenHandler {
@@ -40,10 +33,9 @@ struct DeviceCodeTokenHandler {
                                                              description: errorDescription)
         }
 
-        // Check if the device code is expired
         if deviceCode.expiryDate < Date() {
-            let errorDescription = "Device code has expired"
-            return try tokenResponseGenerator.createResponse(error: OAuthResponseParameters.ErrorType.expiredToken,
+            let errorDescription = "The device code provided was invalid or expired"
+            return try tokenResponseGenerator.createResponse(error: "expired_token",
                                                              description: errorDescription)
         }
 

--- a/Sources/VaporOAuth/Utilities/OAuthFlowType.swift
+++ b/Sources/VaporOAuth/Utilities/OAuthFlowType.swift
@@ -5,4 +5,5 @@ public enum OAuthFlowType: String {
     case clientCredentials = "client_credentials"
     case refresh = "refresh_token"
     case tokenIntrospection = "token_introspection"
+    case deviceCode = "urn:ietf:params:oauth:grant-type:device_code"
 }

--- a/Sources/VaporOAuth/Utilities/StringDefines.swift
+++ b/Sources/VaporOAuth/Utilities/StringDefines.swift
@@ -13,6 +13,7 @@ struct OAuthRequestParameters {
     static let usernname = "username"
     static let csrfToken = "csrfToken"
     static let token = "token"
+    static let deviceCode = "device_code"
 }
 
 struct OAuthResponseParameters {

--- a/Sources/VaporOAuth/Utilities/StringDefines.swift
+++ b/Sources/VaporOAuth/Utilities/StringDefines.swift
@@ -40,6 +40,7 @@ struct OAuthResponseParameters {
         static let unsupportedGrant = "unsupported_grant_type"
         static let invalidGrant = "invalid_grant"
         static let missingToken = "missing_token"
+        static let expiredToken = "expired_token"
     }
 }
 

--- a/Sources/VaporOAuth/Validators/ClientValidator.swift
+++ b/Sources/VaporOAuth/Validators/ClientValidator.swift
@@ -62,6 +62,10 @@ struct ClientValidator {
                     throw ClientError.notFirstParty
                 }
             }
+            
+            if grantType == .deviceCode {
+                
+            }
         }
 
         if checkConfidentialClient {

--- a/Tests/VaporOAuthTests/GrantTests/DeviceCodeGrantTests.swift
+++ b/Tests/VaporOAuthTests/GrantTests/DeviceCodeGrantTests.swift
@@ -1,8 +1,1 @@
-//
-//  File.swift
-//  
-//
-//  Created by Vamsi Madduluri on 24/08/23.
-//
-
 import Foundation

--- a/Tests/VaporOAuthTests/GrantTests/DeviceCodeGrantTests.swift
+++ b/Tests/VaporOAuthTests/GrantTests/DeviceCodeGrantTests.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Vamsi Madduluri on 24/08/23.
+//
+
+import Foundation


### PR DESCRIPTION
In the ongoing efforts to re-implement the Device Code Flow Integration into Vapor OAuth (PR https://github.com/brokenhandsio/vapor-oauth/pull/26), this pull request introduces an essential for handling device code validations.